### PR TITLE
Add Nix dev shell for Go toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ go.work.sum
 
 # env file
 .env
+
+# Nix / local Go toolchain state
+result
+.gopath/
+.gocache/

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "CoreDNS ConsulKV plugin - Go development environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            go
+          ];
+
+          shellHook = ''
+            export GOPATH="$PWD/.gopath"
+            export PATH="$GOPATH/bin:$PATH"
+            echo "Go dev shell: $(go version)"
+          '';
+        };
+      });
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+# Development shell for the CoreDNS ConsulKV plugin.
+# Usage: nix-shell   (then `go build ./...`, `go test ./...`)
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  packages = with pkgs; [
+    go
+  ];
+
+  shellHook = ''
+    export GOPATH="$PWD/.gopath"
+    export PATH="$GOPATH/bin:$PATH"
+    echo "Go dev shell: $(go version)"
+  '';
+}


### PR DESCRIPTION
Adds `shell.nix` and `flake.nix` that expose the Go compiler, so the plugin builds and tests without a system-wide Go install.

- `nix-shell` (or `nix develop`) drops into a shell with `go` on PATH.
- `.gitignore` now excludes local toolchain state (`.gopath`, `.gocache`, `result`).

No source changes.