### PR TITLE
Fix startup panic, config race, and reload panic

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,15 +1,34 @@
 package consulkv
 
 import (
+	"sync/atomic"
+
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/plugin"
+	"github.com/mwantia/coredns-consulkv-plugin/logging"
 	"github.com/mwantia/coredns-consulkv-plugin/types"
 )
 
 type ConsulKVPlugin struct {
 	Next   plugin.Handler
 	Consul *ConsulConfig
-	Config *ConsulKVConfig
+	config atomic.Pointer[ConsulKVConfig]
+}
+
+// GetConfig returns the current configuration snapshot. It never returns nil,
+// so callers can read it without a nil check even before the first config load.
+func (plug *ConsulKVPlugin) GetConfig() *ConsulKVConfig {
+	if config := plug.config.Load(); config != nil {
+		return config
+	}
+
+	return &ConsulKVConfig{}
+}
+
+// SetConfig atomically replaces the active configuration. It is safe to call
+// from the Consul watch goroutine while requests read the config concurrently.
+func (plug *ConsulKVPlugin) SetConfig(config *ConsulKVConfig) {
+	plug.config.Store(config)
 }
 
 type ConsulKVConfig struct {
@@ -40,8 +59,13 @@ func CreatePlugin(c *caddy.Controller) (*ConsulKVPlugin, error) {
 		return nil, err
 	}
 
+	if config == nil {
+		logging.Log.Warningf("No configuration found at '%s/config'; starting with an empty zone set", consul.KVPrefix)
+		config = &ConsulKVConfig{}
+	}
+
 	plug.Consul = consul
-	plug.Config = config
+	plug.SetConfig(config)
 
 	return plug, nil
 }

--- a/consul_client.go
+++ b/consul_client.go
@@ -217,7 +217,7 @@ func CreateQueryOptions(cache *ConsulKVCache) *api.QueryOptions {
 			options.UseCache = *cache.UseCache
 		}
 		if cache.MaxAge != nil {
-			options.MaxAge = time.Duration(*cache.MaxAge)
+			options.MaxAge = time.Duration(*cache.MaxAge) * time.Second
 		}
 		if cache.Consistent != nil {
 			options.RequireConsistent = *cache.Consistent

--- a/consul_watcher.go
+++ b/consul_watcher.go
@@ -46,28 +46,28 @@ func (consul ConsulConfig) WatchConsulKey(key string, fn handler) error {
 	return nil
 }
 
-func (consul ConsulConfig) WatchConsulConfig(config *ConsulKVConfig) error {
-	i := 0
-	err := consul.WatchConsulKey("config", func(kv *api.KVPair) error {
-		if i > 0 {
-			if err := json.Unmarshal(kv.Value, &config); err != nil {
-				logging.Log.Errorf("%s", err)
-
-				IncrementMetricsConsulConfigUpdatedTotal("ERROR")
-				return err
-			}
-
-			logging.Log.Infof("Updated Consul Config from '%s/config'", consul.KVPrefix)
-			IncrementMetricsConsulConfigUpdatedTotal("NOERROR")
+func (consul ConsulConfig) WatchConsulConfig(onUpdate func(*ConsulKVConfig)) error {
+	first := true
+	return consul.WatchConsulKey("config", func(kv *api.KVPair) error {
+		// The watch fires immediately with the value already loaded at startup;
+		// skip that first delivery and only act on subsequent updates.
+		if first {
+			first = false
+			return nil
 		}
-		i++
+
+		config := &ConsulKVConfig{}
+		if err := json.Unmarshal(kv.Value, config); err != nil {
+			logging.Log.Errorf("Unable to parse updated Consul config: %v", err)
+
+			IncrementMetricsConsulConfigUpdatedTotal("ERROR")
+			return err
+		}
+
+		onUpdate(config)
+
+		logging.Log.Infof("Updated Consul Config from '%s/config'", consul.KVPrefix)
+		IncrementMetricsConsulConfigUpdatedTotal("NOERROR")
 		return nil
 	})
-
-	if err != nil {
-
-		return err
-	}
-
-	return nil
 }

--- a/consulkv.go
+++ b/consulkv.go
@@ -10,18 +10,19 @@ import (
 	"github.com/mwantia/coredns-consulkv-plugin/records"
 )
 
-func (plug ConsulKVPlugin) Name() string { return "consulkv" }
+func (plug *ConsulKVPlugin) Name() string { return "consulkv" }
 
-func (plug ConsulKVPlugin) ServeDNS(ctx context.Context, writer dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (plug *ConsulKVPlugin) ServeDNS(ctx context.Context, writer dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: writer, Req: r}
 	qname := state.Name()
 	qtype := state.QType()
+	config := plug.GetConfig()
 
 	logging.Log.Debugf("Received query for %s", qname)
 
-	zname, rname := GetZoneAndRecord(plug.Config.Zones, qname)
+	zname, rname := GetZoneAndRecord(config.Zones, qname)
 	if zname == "" {
-		logging.Log.Debugf("Name %s not in configured zones %s, passing to next plugin", qname, plug.Config.Zones)
+		logging.Log.Debugf("Name %s not in configured zones %s, passing to next plugin", qname, config.Zones)
 
 		return plugin.NextOrFailure(plug.Name(), plug.Next, ctx, writer, r)
 	}
@@ -29,7 +30,7 @@ func (plug ConsulKVPlugin) ServeDNS(ctx context.Context, writer dns.ResponseWrit
 	logging.Log.Debugf("Received new request for zone '%s' and record '%s' with code '%s", zname, rname, dns.TypeToString[qtype])
 	IncrementMetricsQueryRequestsTotal(zname, qtype)
 
-	record, err := plug.Consul.GetZoneRecordFromConsul(zname, rname, plug.Config.ConsulCache)
+	record, err := plug.Consul.GetZoneRecordFromConsul(zname, rname, config.ConsulCache)
 	if err != nil {
 		logging.Log.Errorf("Error receiving value for zone '%s' and name '%s': %v", zname, rname, err)
 		IncrementMetricsPluginErrorsTotal("CONSUL_GET")
@@ -45,8 +46,9 @@ func (plug ConsulKVPlugin) ServeDNS(ctx context.Context, writer dns.ResponseWrit
 	return plug.CreateDNSResponse(qname, qtype, record, ctx, r, writer)
 }
 
-func (plug ConsulKVPlugin) HandleMissingRecord(qname string, qtype uint16, zname string, rname string, ctx context.Context, writer dns.ResponseWriter, r *dns.Msg) (int, error) {
-	soa, err := plug.Consul.GetSOARecordFromConsul(zname, plug.Config.ConsulCache)
+func (plug *ConsulKVPlugin) HandleMissingRecord(qname string, qtype uint16, zname string, rname string, ctx context.Context, writer dns.ResponseWriter, r *dns.Msg) (int, error) {
+	config := plug.GetConfig()
+	soa, err := plug.Consul.GetSOARecordFromConsul(zname, config.ConsulCache)
 	if err != nil {
 		logging.Log.Errorf("Error loading SOA record: %v", err)
 
@@ -62,7 +64,7 @@ func (plug ConsulKVPlugin) HandleMissingRecord(qname string, qtype uint16, zname
 		return HandleNXDomain(qname, soa, r, writer)
 	}
 
-	record, err := plug.Consul.GetZoneRecordFromConsul(zname, "*", plug.Config.ConsulCache)
+	record, err := plug.Consul.GetZoneRecordFromConsul(zname, "*", config.ConsulCache)
 	if err != nil {
 		logging.Log.Errorf("Error receiving value for zone '%s' and name '*': %v", zname, err)
 
@@ -81,13 +83,13 @@ func (plug ConsulKVPlugin) HandleMissingRecord(qname string, qtype uint16, zname
 	return plug.CreateDNSResponse(qname, qtype, record, ctx, r, writer)
 }
 
-func (plug ConsulKVPlugin) CreateDNSResponse(qname string, qtype uint16, record *records.Record, ctx context.Context, r *dns.Msg, writer dns.ResponseWriter) (int, error) {
+func (plug *ConsulKVPlugin) CreateDNSResponse(qname string, qtype uint16, record *records.Record, ctx context.Context, r *dns.Msg, writer dns.ResponseWriter) (int, error) {
 	msg := PrepareResponseReply(r, false)
 
 	logging.Log.Debugf("Creating DNS response for %s", qname)
 
 	handled := plug.HandleRecord(ctx, msg, qname, qtype, record)
-	zname, _ := GetZoneAndRecord(plug.Config.Zones, qname)
+	zname, _ := GetZoneAndRecord(plug.GetConfig().Zones, qname)
 
 	if handled && len(msg.Answer) > 0 {
 		return SendDNSResponse(zname, qtype, msg, writer)
@@ -115,13 +117,14 @@ func SendDNSResponse(zname string, qtype uint16, msg *dns.Msg, writer dns.Respon
 	return dns.RcodeSuccess, nil
 }
 
-func (plug ConsulKVPlugin) HandleNoMatchingRecords(qname string, qtype uint16, ctx context.Context, request *dns.Msg, writer dns.ResponseWriter) (int, error) {
-	zname, rname := GetZoneAndRecord(plug.Config.Zones, qname)
+func (plug *ConsulKVPlugin) HandleNoMatchingRecords(qname string, qtype uint16, ctx context.Context, request *dns.Msg, writer dns.ResponseWriter) (int, error) {
+	config := plug.GetConfig()
+	zname, rname := GetZoneAndRecord(config.Zones, qname)
 
 	logging.Log.Infof("No matching record was found for zone '%s' and record '%s' with code '%s'",
 		zname, rname, dns.TypeToString[qtype])
 
-	soa, err := plug.Consul.GetSOARecordFromConsul(zname, plug.Config.ConsulCache)
+	soa, err := plug.Consul.GetSOARecordFromConsul(zname, config.ConsulCache)
 	if err != nil {
 		logging.Log.Errorf("Error loading SOA record: %v", err)
 

--- a/consulkv_test.go
+++ b/consulkv_test.go
@@ -47,7 +47,7 @@ func TestConsulKV(tst *testing.T) {
 	}
 
 	plug.Consul = consul
-	plug.Config = config
+	plug.SetConfig(config)
 
 	tests := GenerateTestCases()
 	RunTests(tst, plug, tests)

--- a/crash_test.go
+++ b/crash_test.go
@@ -1,0 +1,89 @@
+package consulkv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/miekg/dns"
+)
+
+type passthroughHandler struct {
+	called bool
+}
+
+func (h *passthroughHandler) Name() string { return "passthrough" }
+
+func (h *passthroughHandler) ServeDNS(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	h.called = true
+	m := new(dns.Msg)
+	m.SetReply(r)
+	if err := w.WriteMsg(m); err != nil {
+		return dns.RcodeServerFailure, err
+	}
+	return dns.RcodeSuccess, nil
+}
+
+// TestServeDNSWithoutConfigDoesNotPanic covers the startup case where the
+// Consul '<prefix>/config' key is absent: the plugin must serve requests
+// (passing them to the next plugin) instead of dereferencing a nil config.
+func TestServeDNSWithoutConfigDoesNotPanic(t *testing.T) {
+	next := &passthroughHandler{}
+	plug := &ConsulKVPlugin{Next: next}
+	// Deliberately no SetConfig: GetConfig must return a usable empty config.
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	code, err := plug.ServeDNS(context.TODO(), rec, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != dns.RcodeSuccess {
+		t.Fatalf("code = %d, want %d (passthrough)", code, dns.RcodeSuccess)
+	}
+	if !next.called {
+		t.Fatal("expected the query to be passed to the next plugin")
+	}
+}
+
+// TestCreateQueryOptionsMaxAgeSeconds pins the documented unit for max_age:
+// the configured integer is seconds, not nanoseconds.
+func TestCreateQueryOptionsMaxAgeSeconds(t *testing.T) {
+	age := 60
+	opts := CreateQueryOptions(&ConsulKVCache{MaxAge: &age})
+
+	if opts.MaxAge != 60*time.Second {
+		t.Fatalf("MaxAge = %v, want %v", opts.MaxAge, 60*time.Second)
+	}
+}
+
+// TestRegisterMetricsIsIdempotent guards against the duplicate-registration
+// panic CoreDNS would otherwise hit when setup runs again on a reload.
+func TestRegisterMetricsIsIdempotent(t *testing.T) {
+	registerMetrics()
+	registerMetrics()
+}
+
+// TestConfigSwapIsRaceFree exercises concurrent reads and writes of the config
+// so `go test -race` flags any regression to unsynchronized access.
+func TestConfigSwapIsRaceFree(t *testing.T) {
+	plug := &ConsulKVPlugin{}
+	plug.SetConfig(&ConsulKVConfig{Zones: []string{"a.example."}})
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			plug.SetConfig(&ConsulKVConfig{Zones: []string{"b.example."}})
+		}
+		close(done)
+	}()
+
+	for i := 0; i < 1000; i++ {
+		_ = plug.GetConfig().Zones
+	}
+	<-done
+}

--- a/metrics.go
+++ b/metrics.go
@@ -81,4 +81,18 @@ func IncrementMetricsResponsesFailedTotal(zone string, qtype uint16, err string)
 	metricsQueryResponsesFailedTotal.WithLabelValues(dns.Fqdn(zone), t, err).Inc()
 }
 
-var _ sync.Once
+var metricsOnce sync.Once
+
+// registerMetrics registers all plugin collectors exactly once. CoreDNS runs
+// setup again on every reload (SIGUSR1); without the guard a second
+// prometheus.MustRegister would panic with a duplicate-registration error.
+func registerMetrics() {
+	metricsOnce.Do(func() {
+		prometheus.MustRegister(metricsPluginErrorsTotal)
+		prometheus.MustRegister(metricsConsulConfigUpdatedTotal)
+		prometheus.MustRegister(metricsConsulRequestDurationSeconds)
+		prometheus.MustRegister(metricsQueryRequestsTotal)
+		prometheus.MustRegister(metricsQueryResponsesSuccessfulTotal)
+		prometheus.MustRegister(metricsQueryResponsesFailedTotal)
+	})
+}

--- a/ready.go
+++ b/ready.go
@@ -6,12 +6,12 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-func (config ConsulKVPlugin) Ready() bool {
-	if config.Consul == nil {
+func (plug *ConsulKVPlugin) Ready() bool {
+	if plug.Consul == nil {
 		return false
 	}
 
-	_, _, err := config.Consul.Client.Health().Service("consul", "", false, &api.QueryOptions{
+	_, _, err := plug.Consul.Client.Health().Service("consul", "", false, &api.QueryOptions{
 		AllowStale:        true,
 		UseCache:          true,
 		MaxAge:            1 * time.Second,

--- a/record_cname.go
+++ b/record_cname.go
@@ -26,26 +26,28 @@ func (plug *ConsulKVPlugin) AppendCNAMERecords(ctx context.Context, msg *dns.Msg
 	}
 	msg.Answer = append(msg.Answer, rr)
 
-	if plug.Config.Flattening == types.Flattening_None {
+	config := plug.GetConfig()
+
+	if config.Flattening == types.Flattening_None {
 		logging.Log.Debugf("CNAME flattening disabled; Only returning CNAME record for '%s'", alias)
 
 		return true
 	}
 
-	zname, rname := GetZoneAndRecord(plug.Config.Zones, alias)
+	zname, rname := GetZoneAndRecord(config.Zones, alias)
 	if zname == "" {
-		if plug.Config.Flattening == types.Flattening_Full {
-			logging.Log.Debugf("Zone %s not in configured zones %s, passing to next plugin ", zname, plug.Config.Zones)
+		if config.Flattening == types.Flattening_Full {
+			logging.Log.Debugf("Zone %s not in configured zones %s, passing to next plugin ", zname, config.Zones)
 			return plug.HandleExternalCNAME(ctx, msg, alias, qtype)
 		}
 
-		logging.Log.Debugf("Zone %s not in configured zones %s, skipping CNAME flattening", zname, plug.Config.Zones)
+		logging.Log.Debugf("Zone %s not in configured zones %s, skipping CNAME flattening", zname, config.Zones)
 		return true
 	}
 
 	logging.Log.Debugf("Received new request for zone '%s' and record '%s' with code '%s", zname, rname, dns.TypeToString[qtype])
 
-	record, err := plug.Consul.GetZoneRecordFromConsul(zname, rname, plug.Config.ConsulCache)
+	record, err := plug.Consul.GetZoneRecordFromConsul(zname, rname, config.ConsulCache)
 	if err != nil {
 		logging.Log.Errorf("Error receiving value for zone '%s' and name '%s': %v", zname, rname, err)
 		IncrementMetricsPluginErrorsTotal("CONSUL_GET")

--- a/record_handler.go
+++ b/record_handler.go
@@ -14,8 +14,9 @@ func (plug *ConsulKVPlugin) HandleRecord(ctx context.Context, msg *dns.Msg, qnam
 
 	logging.Log.Debugf("Amount of available records: %v", len(record.Records))
 
-	zname, _ := GetZoneAndRecord(plug.Config.Zones, qname)
-	soa, err := plug.Consul.GetSOARecordFromConsul(zname, plug.Config.ConsulCache)
+	config := plug.GetConfig()
+	zname, _ := GetZoneAndRecord(config.Zones, qname)
+	soa, err := plug.Consul.GetSOARecordFromConsul(zname, config.ConsulCache)
 
 	if err != nil {
 		logging.Log.Errorf("Error loading SOA record: %v", err)

--- a/setup.go
+++ b/setup.go
@@ -7,7 +7,6 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/mwantia/coredns-consulkv-plugin/logging"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 var soaSerial = uint32(time.Now().Unix())
@@ -18,12 +17,7 @@ func init() {
 
 func setup(c *caddy.Controller) error {
 	c.OnStartup(func() error {
-		prometheus.MustRegister(metricsPluginErrorsTotal)
-		prometheus.MustRegister(metricsConsulConfigUpdatedTotal)
-		prometheus.MustRegister(metricsConsulRequestDurationSeconds)
-		prometheus.MustRegister(metricsQueryRequestsTotal)
-		prometheus.MustRegister(metricsQueryResponsesSuccessfulTotal)
-		prometheus.MustRegister(metricsQueryResponsesFailedTotal)
+		registerMetrics()
 		return nil
 	})
 
@@ -33,7 +27,7 @@ func setup(c *caddy.Controller) error {
 	}
 
 	if !conf.Consul.DisableWatch {
-		err = conf.Consul.WatchConsulConfig(conf.Config)
+		err = conf.Consul.WatchConsulConfig(conf.SetConfig)
 		if err != nil {
 			logging.Log.Warningf("Unable to create Consul watcher for '%s/config'", conf.Consul.KVPrefix)
 		}


### PR DESCRIPTION
Fixes three crash-class bugs plus a cache-unit bug found in the code audit.

## Changes
- **Startup nil-config panic.** `GetConfigFromConsul` returns `(nil, nil)` when the `<prefix>/config` key is absent. The config is now stored in an `atomic.Pointer` and read through `GetConfig()`, which never returns nil; a missing key yields an empty config and a passthrough instead of a nil dereference on the first query.
- **Config data race.** The Consul watch goroutine used to `json.Unmarshal` into the same `*ConsulKVConfig` that `ServeDNS` reads. It now builds a new config and swaps it in atomically via `SetConfig`.
- **Reload panic.** Prometheus collectors are registered once behind a `sync.Once`, so a CoreDNS reload (SIGUSR1) no longer panics with a duplicate-registration error.
- **Cache `max_age` unit.** Interpreted as seconds (matching the docs and the default), not nanoseconds.

Plugin value receivers became pointer receivers, required now that the struct holds an `atomic.Pointer`.

## Tests
Adds hermetic tests in `crash_test.go`:
- `TestServeDNSWithoutConfigDoesNotPanic` — passthrough when no config is loaded.
- `TestCreateQueryOptionsMaxAgeSeconds` — `max_age: 60` maps to 60s.
- `TestRegisterMetricsIsIdempotent` — double registration does not panic.
- `TestConfigSwapIsRaceFree` — concurrent read/write, clean under `-race`.

`go build`, `go vet`, and the new tests (with `-race`) all pass. The pre-existing `TestConsulKV` still requires a live Consul and is unchanged.