### PR TITLE
Fix CNAME flattening, zone matching, SOA errors, and IP validation

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,15 @@ func (plug *ConsulKVPlugin) SetConfig(config *ConsulKVConfig) {
 	plug.config.Store(config)
 }
 
+// ApplyDefaults fills in values the operator may omit. Flattening defaults to
+// "local" (the documented default); its zero value "" would otherwise fall
+// through the disable-flattening guard and behave like "local" only by accident.
+func (config *ConsulKVConfig) ApplyDefaults() {
+	if config.Flattening == "" {
+		config.Flattening = types.Flattening_Local
+	}
+}
+
 type ConsulKVConfig struct {
 	ZonePrefix  string               `json:"zone_prefix"`
 	Zones       []string             `json:"zones"`

--- a/consul_client.go
+++ b/consul_client.go
@@ -154,6 +154,8 @@ func (consul *ConsulConfig) GetConfigFromConsul() (*ConsulKVConfig, error) {
 		return nil, err
 	}
 
+	config.ApplyDefaults()
+
 	IncrementMetricsConsulRequestDurationSeconds("NOERROR", duration)
 	return &config, nil
 }
@@ -185,13 +187,15 @@ func (consul ConsulConfig) GetZoneRecordFromConsul(zone, name string, cache *Con
 
 func (consul ConsulConfig) GetSOARecordFromConsul(zone string, cache *ConsulKVCache) (*records.SOARecord, error) {
 	record, err := consul.GetZoneRecordFromConsul(zone, "@", cache)
+	if err != nil {
+		return nil, err
+	}
 
 	if record != nil {
 		for _, rec := range record.Records {
 			if rec.Type == "SOA" {
 				var soa records.SOARecord
-				err = json.Unmarshal(rec.Value, &soa)
-				if err != nil {
+				if err := json.Unmarshal(rec.Value, &soa); err != nil {
 					return nil, err
 				}
 
@@ -200,7 +204,7 @@ func (consul ConsulConfig) GetSOARecordFromConsul(zone string, cache *ConsulKVCa
 		}
 	}
 
-	return GetDefaultSOA(zone), err
+	return GetDefaultSOA(zone), nil
 }
 
 func CreateQueryOptions(cache *ConsulKVCache) *api.QueryOptions {

--- a/consul_watcher.go
+++ b/consul_watcher.go
@@ -64,6 +64,7 @@ func (consul ConsulConfig) WatchConsulConfig(onUpdate func(*ConsulKVConfig)) err
 			return err
 		}
 
+		config.ApplyDefaults()
 		onUpdate(config)
 
 		logging.Log.Infof("Updated Consul Config from '%s/config'", consul.KVPrefix)

--- a/record_cname.go
+++ b/record_cname.go
@@ -56,7 +56,7 @@ func (plug *ConsulKVPlugin) AppendCNAMERecords(ctx context.Context, msg *dns.Msg
 	}
 
 	if record != nil {
-		return plug.HandleRecord(ctx, msg, rname, dns.TypeA, record)
+		return plug.HandleRecord(ctx, msg, rname, qtype, record)
 	}
 
 	logging.Log.Debugf("No record found for alias '%s' and type '%s'", alias, dns.TypeToString[qtype])
@@ -67,6 +67,8 @@ func (plug *ConsulKVPlugin) AppendCNAMERecords(ctx context.Context, msg *dns.Msg
 func (plug *ConsulKVPlugin) HandleExternalCNAME(ctx context.Context, msg *dns.Msg, alias string, qtype uint16) bool {
 	logging.Log.Debugf("Resolving external CNAME target: %s", alias)
 
+	before := len(msg.Answer)
+
 	request := request.Request{W: &ResponseWriterWrapper{WrappedMsg: msg}, Req: new(dns.Msg)}
 	request.Req.SetQuestion(dns.Fqdn(alias), qtype)
 
@@ -76,5 +78,5 @@ func (plug *ConsulKVPlugin) HandleExternalCNAME(ctx context.Context, msg *dns.Ms
 		return false
 	}
 
-	return len(msg.Answer) > len(msg.Answer)-1
+	return len(msg.Answer) > before
 }

--- a/record_handler.go
+++ b/record_handler.go
@@ -2,148 +2,155 @@ package consulkv
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/miekg/dns"
 	"github.com/mwantia/coredns-consulkv-plugin/logging"
 	"github.com/mwantia/coredns-consulkv-plugin/records"
 )
 
+// appendRequest carries everything an appender needs to add records of a single
+// type to the response being built.
+type appendRequest struct {
+	msg   *dns.Msg
+	qname string
+	qtype uint16
+	ttl   int
+	value json.RawMessage
+	soa   *records.SOARecord
+	found bool
+}
+
+// recordAppenders maps a stored record type to the logic that appends it. Each
+// appender first checks whether it applies to the query type and returns
+// (false, nil) when it does not, so HandleRecord stays a simple dispatch loop.
+//
+// CNAME is handled separately in HandleRecord: it recurses back into
+// HandleRecord for flattening, which would create a static initialization cycle
+// if referenced from this package-level map.
+var recordAppenders = map[string]func(*appendRequest) (bool, error){
+	"NS": func(r *appendRequest) (bool, error) {
+		if r.qtype == dns.TypeNS {
+			return records.AppendNSRecords(r.msg, r.qname, r.ttl, r.value)
+		}
+		return false, nil
+	},
+	"SVCB": func(r *appendRequest) (bool, error) {
+		if r.qtype == dns.TypeSVCB {
+			return records.AppendSVCBRecords(r.msg, r.qname, r.ttl, r.value, dns.TypeSVCB)
+		}
+		return false, nil
+	},
+	"HTTPS": func(r *appendRequest) (bool, error) {
+		if r.qtype == dns.TypeHTTPS {
+			return records.AppendSVCBRecords(r.msg, r.qname, r.ttl, r.value, dns.TypeHTTPS)
+		}
+		return false, nil
+	},
+	"SOA": func(r *appendRequest) (bool, error) {
+		if r.qtype == dns.TypeSOA || r.qtype == dns.TypeANY {
+			return records.AppendSOARecord(r.msg, r.qname, r.soa), nil
+		}
+		return false, nil
+	},
+	"A": func(r *appendRequest) (bool, error) {
+		if r.qtype == dns.TypeA || (r.qtype == dns.TypeHTTPS && !r.found) {
+			return records.AppendARecords(r.msg, r.qname, r.ttl, r.value)
+		}
+		return false, nil
+	},
+	"AAAA": func(r *appendRequest) (bool, error) {
+		if r.qtype == dns.TypeAAAA || (r.qtype == dns.TypeHTTPS && !r.found) {
+			return records.AppendAAAARecords(r.msg, r.qname, r.ttl, r.value)
+		}
+		return false, nil
+	},
+	"PTR": func(r *appendRequest) (bool, error) {
+		if r.qtype != dns.TypePTR {
+			return false, nil
+		}
+		if records.IsDnsSdQuery(r.qname) {
+			return records.AppendDnsSdPTRRecords(r.msg, r.qname, r.ttl, r.value)
+		}
+		return records.AppendPTRRecords(r.msg, r.qname, r.ttl, r.value)
+	},
+	"SRV": func(r *appendRequest) (bool, error) {
+		if r.qtype == dns.TypeSRV {
+			return records.AppendSRVRecords(r.msg, r.qname, r.ttl, r.value)
+		}
+		return false, nil
+	},
+	"TXT": func(r *appendRequest) (bool, error) {
+		if r.qtype == dns.TypeTXT {
+			return records.AppendTXTRecords(r.msg, r.qname, r.ttl, r.value)
+		}
+		return false, nil
+	},
+}
+
 func (plug *ConsulKVPlugin) HandleRecord(ctx context.Context, msg *dns.Msg, qname string, qtype uint16, record *records.Record) bool {
 	ttl := GetDefaultTTL(record)
-	foundRequestedType := false
 
 	logging.Log.Debugf("Amount of available records: %v", len(record.Records))
 
 	config := plug.GetConfig()
 	zname, _ := GetZoneAndRecord(config.Zones, qname)
 	soa, err := plug.Consul.GetSOARecordFromConsul(zname, config.ConsulCache)
-
 	if err != nil {
 		logging.Log.Errorf("Error loading SOA record: %v", err)
 		IncrementMetricsPluginErrorsTotal("SOA_GET")
 	}
 
+	found := false
 	for _, rec := range record.Records {
 		logging.Log.Debugf("Searching record for type %s", rec.Type)
 
-		switch rec.Type {
-		case "CNAME":
-			if qtype == dns.TypeCNAME || qtype == dns.TypeA || qtype == dns.TypeAAAA || qtype == dns.TypeTXT || (qtype == dns.TypeHTTPS && !foundRequestedType) {
-				foundRequestedType = plug.AppendCNAMERecords(ctx, msg, qname, qtype, ttl, rec.Value)
+		if rec.Type == "CNAME" {
+			if cnameAppliesTo(qtype, found) &&
+				plug.AppendCNAMERecords(ctx, msg, qname, qtype, ttl, rec.Value) {
+				found = true
 			}
+			continue
+		}
 
-		case "NS":
-			if qtype == dns.TypeNS {
-				found, err := records.AppendNSRecords(msg, qname, ttl, rec.Value)
-				if err != nil {
-					logging.Log.Errorf("Error parsing JSON for NS record: %v", err)
-					IncrementMetricsPluginErrorsTotal("JSON_UNMARSHAL")
-				}
+		appender, ok := recordAppenders[rec.Type]
+		if !ok {
+			continue
+		}
 
-				foundRequestedType = found
-			}
-
-		case "SVCB":
-			if qtype == dns.TypeSVCB {
-				found, err := records.AppendSVCBRecords(msg, qname, ttl, rec.Value, dns.TypeSVCB)
-				if err != nil {
-					logging.Log.Errorf("Error parsing JSON for SVCB record: %v", err)
-					IncrementMetricsPluginErrorsTotal("JSON_UNMARSHAL")
-				}
-
-				foundRequestedType = found
-			}
-
-		case "HTTPS":
-			if qtype == dns.TypeHTTPS {
-				found, err := records.AppendSVCBRecords(msg, qname, ttl, rec.Value, dns.TypeHTTPS)
-				if err != nil {
-					logging.Log.Errorf("Error parsing JSON for HTTPS record: %v", err)
-					IncrementMetricsPluginErrorsTotal("JSON_UNMARSHAL")
-				}
-
-				foundRequestedType = found
-			}
-
-		case "SOA":
-			if qtype == dns.TypeSOA || qtype == dns.TypeANY {
-				foundRequestedType = records.AppendSOARecord(msg, qname, soa)
-			}
-
-		case "A":
-			if qtype == dns.TypeA || (qtype == dns.TypeHTTPS && !foundRequestedType) {
-				found, err := records.AppendARecords(msg, qname, ttl, rec.Value)
-				if err != nil {
-					logging.Log.Errorf("Error parsing JSON for A record: %v", err)
-					IncrementMetricsPluginErrorsTotal("JSON_UNMARSHAL")
-				}
-
-				foundRequestedType = found
-			}
-
-		case "AAAA":
-			if qtype == dns.TypeAAAA || (qtype == dns.TypeHTTPS && !foundRequestedType) {
-				found, err := records.AppendAAAARecords(msg, qname, ttl, rec.Value)
-				if err != nil {
-					logging.Log.Errorf("Error parsing JSON for AAAA record: %v", err)
-					IncrementMetricsPluginErrorsTotal("JSON_UNMARSHAL")
-				}
-
-				foundRequestedType = found
-			}
-
-		case "PTR":
-			if qtype == dns.TypePTR {
-				if records.IsDnsSdQuery(qname) {
-					found, err := records.AppendDnsSdPTRRecords(msg, qname, ttl, rec.Value)
-					if err != nil {
-						logging.Log.Errorf("Error parsing JSON for DNS-SD record: %v", err)
-						IncrementMetricsPluginErrorsTotal("JSON_UNMARSHAL")
-					}
-
-					foundRequestedType = found
-				} else {
-					found, err := records.AppendPTRRecords(msg, qname, ttl, rec.Value)
-					if err != nil {
-						logging.Log.Errorf("Error parsing JSON for PTR record: %v", err)
-						IncrementMetricsPluginErrorsTotal("JSON_UNMARSHAL")
-					}
-
-					foundRequestedType = found
-				}
-			}
-
-		case "SRV":
-			if qtype == dns.TypeSRV {
-				found, err := records.AppendSRVRecords(msg, qname, ttl, rec.Value)
-				if err != nil {
-					logging.Log.Errorf("Error parsing JSON for SRV record: %v", err)
-					IncrementMetricsPluginErrorsTotal("JSON_UNMARSHAL")
-				}
-
-				foundRequestedType = found
-			}
-
-		case "TXT":
-			txtAnswered, err := records.AppendTXTRecords(msg, qtype, qname, ttl, rec.Value)
-			if err != nil {
-				logging.Log.Errorf("Error parsing JSON for TXT record: %v", err)
-				IncrementMetricsPluginErrorsTotal("JSON_UNMARSHAL")
-			}
-
-			if txtAnswered {
-				foundRequestedType = txtAnswered
-			}
+		req := &appendRequest{msg, qname, qtype, ttl, rec.Value, soa, found}
+		matched, err := appender(req)
+		if err != nil {
+			logging.Log.Errorf("Error parsing JSON for %s record: %v", rec.Type, err)
+			IncrementMetricsPluginErrorsTotal("JSON_UNMARSHAL")
+			continue
+		}
+		if matched {
+			found = true
 		}
 	}
 
-	if (qtype == dns.TypeSVCB || qtype == dns.TypeHTTPS) && !foundRequestedType && len(msg.Answer) > 0 {
-		foundRequestedType = true
+	return plug.finalizeAnswer(msg, qname, qtype, soa, found)
+}
+
+// cnameAppliesTo reports whether a CNAME record should be processed for the
+// given query type. A/AAAA/TXT queries flatten through the CNAME, and HTTPS
+// queries follow it only when no direct match has been found yet.
+func cnameAppliesTo(qtype uint16, found bool) bool {
+	return qtype == dns.TypeCNAME || qtype == dns.TypeA || qtype == dns.TypeAAAA ||
+		qtype == dns.TypeTXT || (qtype == dns.TypeHTTPS && !found)
+}
+
+// finalizeAnswer applies the cross-record fallbacks: treat any answer as a match
+// for service-binding queries, and add an authority SOA when nothing matched.
+func (plug *ConsulKVPlugin) finalizeAnswer(msg *dns.Msg, qname string, qtype uint16, soa *records.SOARecord, found bool) bool {
+	if (qtype == dns.TypeSVCB || qtype == dns.TypeHTTPS) && !found && len(msg.Answer) > 0 {
+		found = true
 	}
 
-	if !foundRequestedType && soa != nil && qtype != dns.TypeSOA && qtype != dns.TypeANY {
+	if !found && soa != nil && qtype != dns.TypeSOA && qtype != dns.TypeANY {
 		records.AppendSOAToAuthority(msg, qname, soa)
 	}
 
-	return foundRequestedType
+	return found
 }

--- a/record_handling_test.go
+++ b/record_handling_test.go
@@ -1,0 +1,113 @@
+package consulkv
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/mwantia/coredns-consulkv-plugin/types"
+)
+
+func TestGetZoneAndRecordLabelBoundary(t *testing.T) {
+	zones := []string{"example.com", "0.168.192.in-addr.arpa"}
+
+	cases := []struct {
+		qname    string
+		wantZone string
+		wantRec  string
+	}{
+		{"www.example.com.", "example.com", "www"},
+		{"example.com.", "example.com", "@"},
+		{"a.b.example.com.", "example.com", "a.b"},
+		{"5.0.168.192.in-addr.arpa.", "0.168.192.in-addr.arpa", "5"},
+		// Look-alike domains sharing the suffix must NOT match.
+		{"notexample.com.", "", ""},
+		{"badexample.com.", "", ""},
+		{"other.org.", "", ""},
+	}
+
+	for _, tc := range cases {
+		zone, rec := GetZoneAndRecord(zones, tc.qname)
+		if zone != tc.wantZone || rec != tc.wantRec {
+			t.Errorf("GetZoneAndRecord(%q) = (%q, %q), want (%q, %q)",
+				tc.qname, zone, rec, tc.wantZone, tc.wantRec)
+		}
+	}
+}
+
+func TestApplyDefaultsFlattening(t *testing.T) {
+	empty := &ConsulKVConfig{}
+	empty.ApplyDefaults()
+	if empty.Flattening != types.Flattening_Local {
+		t.Fatalf("default Flattening = %q, want %q", empty.Flattening, types.Flattening_Local)
+	}
+
+	explicit := &ConsulKVConfig{Flattening: types.Flattening_None}
+	explicit.ApplyDefaults()
+	if explicit.Flattening != types.Flattening_None {
+		t.Fatalf("explicit Flattening = %q, want %q (must be preserved)", explicit.Flattening, types.Flattening_None)
+	}
+}
+
+func TestCNAMEAppliesTo(t *testing.T) {
+	cases := []struct {
+		qtype uint16
+		found bool
+		want  bool
+	}{
+		{dns.TypeCNAME, false, true},
+		{dns.TypeA, false, true},
+		{dns.TypeAAAA, false, true},
+		{dns.TypeTXT, false, true},
+		{dns.TypeHTTPS, false, true},
+		{dns.TypeHTTPS, true, false},
+		{dns.TypeNS, false, false},
+		{dns.TypeSRV, false, false},
+	}
+
+	for _, tc := range cases {
+		if got := cnameAppliesTo(tc.qtype, tc.found); got != tc.want {
+			t.Errorf("cnameAppliesTo(%s, %v) = %v, want %v",
+				dns.TypeToString[tc.qtype], tc.found, got, tc.want)
+		}
+	}
+}
+
+type answeringHandler struct {
+	answers []dns.RR
+}
+
+func (h *answeringHandler) Name() string { return "answering" }
+
+func (h *answeringHandler) ServeDNS(_ context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Answer = h.answers
+	if err := w.WriteMsg(m); err != nil {
+		return dns.RcodeServerFailure, err
+	}
+	return dns.RcodeSuccess, nil
+}
+
+func TestHandleExternalCNAMEDetectsResolution(t *testing.T) {
+	answer := &dns.A{
+		Hdr: dns.RR_Header{Name: "target.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+		A:   net.ParseIP("192.0.2.1").To4(),
+	}
+	plug := &ConsulKVPlugin{Next: &answeringHandler{answers: []dns.RR{answer}}}
+
+	msg := new(dns.Msg)
+	if !plug.HandleExternalCNAME(context.TODO(), msg, "target.example.", dns.TypeA) {
+		t.Fatal("expected external resolution that produced an answer to report success")
+	}
+}
+
+func TestHandleExternalCNAMENoAnswerReportsFailure(t *testing.T) {
+	plug := &ConsulKVPlugin{Next: &answeringHandler{answers: nil}}
+
+	msg := new(dns.Msg)
+	if plug.HandleExternalCNAME(context.TODO(), msg, "target.example.", dns.TypeA) {
+		t.Fatal("expected external resolution with no answers to report failure")
+	}
+}

--- a/records/a.go
+++ b/records/a.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/miekg/dns"
+	"github.com/mwantia/coredns-consulkv-plugin/logging"
 )
 
 func AppendARecords(msg *dns.Msg, qname string, ttl int, value json.RawMessage) (bool, error) {
@@ -13,13 +14,21 @@ func AppendARecords(msg *dns.Msg, qname string, ttl int, value json.RawMessage) 
 		return false, err
 	}
 
+	found := false
 	for _, ip := range ips {
+		parsed := net.ParseIP(ip)
+		if parsed == nil || parsed.To4() == nil {
+			logging.Log.Warningf("Skipping invalid IPv4 address %q for A record %s", ip, qname)
+			continue
+		}
+
 		rr := &dns.A{
 			Hdr: dns.RR_Header{Name: dns.Fqdn(qname), Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: uint32(ttl)},
-			A:   net.ParseIP(ip),
+			A:   parsed.To4(),
 		}
 		msg.Answer = append(msg.Answer, rr)
+		found = true
 	}
 
-	return len(ips) > 0, nil
+	return found, nil
 }

--- a/records/aaaa.go
+++ b/records/aaaa.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/miekg/dns"
+	"github.com/mwantia/coredns-consulkv-plugin/logging"
 )
 
 func AppendAAAARecords(msg *dns.Msg, qname string, ttl int, value json.RawMessage) (bool, error) {
@@ -13,13 +14,21 @@ func AppendAAAARecords(msg *dns.Msg, qname string, ttl int, value json.RawMessag
 		return false, err
 	}
 
+	found := false
 	for _, ip := range ips {
+		parsed := net.ParseIP(ip)
+		if parsed == nil || parsed.To4() != nil || parsed.To16() == nil {
+			logging.Log.Warningf("Skipping invalid IPv6 address %q for AAAA record %s", ip, qname)
+			continue
+		}
+
 		rr := &dns.AAAA{
 			Hdr:  dns.RR_Header{Name: dns.Fqdn(qname), Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: uint32(ttl)},
-			AAAA: net.ParseIP(ip),
+			AAAA: parsed.To16(),
 		}
 		msg.Answer = append(msg.Answer, rr)
+		found = true
 	}
 
-	return len(ips) > 0, nil
+	return found, nil
 }

--- a/records/records_test.go
+++ b/records/records_test.go
@@ -1,0 +1,80 @@
+package records
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestAppendARecordsSkipsInvalid(t *testing.T) {
+	msg := new(dns.Msg)
+	// Mix of a valid IPv4, garbage, and an IPv6 (not valid for an A record).
+	ok, err := AppendARecords(msg, "host.example.", 60, json.RawMessage(`["192.0.2.1","not-an-ip","2001:db8::1"]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected a valid A record to be appended")
+	}
+	if len(msg.Answer) != 1 {
+		t.Fatalf("Answer count = %d, want 1 (only the valid IPv4)", len(msg.Answer))
+	}
+	if a, okType := msg.Answer[0].(*dns.A); !okType || a.A.String() != "192.0.2.1" {
+		t.Fatalf("Answer[0] = %v, want A 192.0.2.1", msg.Answer[0])
+	}
+}
+
+func TestAppendARecordsAllInvalidReportsNotFound(t *testing.T) {
+	msg := new(dns.Msg)
+	ok, err := AppendARecords(msg, "host.example.", 60, json.RawMessage(`["nope","2001:db8::1"]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected found=false when no valid IPv4 is present")
+	}
+	if len(msg.Answer) != 0 {
+		t.Fatalf("Answer count = %d, want 0", len(msg.Answer))
+	}
+}
+
+func TestAppendAAAARecordsRejectsIPv4(t *testing.T) {
+	msg := new(dns.Msg)
+	ok, err := AppendAAAARecords(msg, "host.example.", 60, json.RawMessage(`["2001:db8::1","192.0.2.1"]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected a valid AAAA record to be appended")
+	}
+	if len(msg.Answer) != 1 {
+		t.Fatalf("Answer count = %d, want 1 (IPv4 must be rejected)", len(msg.Answer))
+	}
+}
+
+func TestAppendTXTRecords(t *testing.T) {
+	msg := new(dns.Msg)
+	ok, err := AppendTXTRecords(msg, "host.example.", 60, json.RawMessage(`["hello","world"]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok || len(msg.Answer) != 1 {
+		t.Fatalf("ok=%v Answer=%d, want true and 1", ok, len(msg.Answer))
+	}
+	txt, okType := msg.Answer[0].(*dns.TXT)
+	if !okType || len(txt.Txt) != 2 {
+		t.Fatalf("Answer[0] = %v, want TXT with 2 strings", msg.Answer[0])
+	}
+}
+
+func TestAppendTXTRecordsEmpty(t *testing.T) {
+	msg := new(dns.Msg)
+	ok, err := AppendTXTRecords(msg, "host.example.", 60, json.RawMessage(`[]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok || len(msg.Answer) != 0 {
+		t.Fatalf("ok=%v Answer=%d, want false and 0", ok, len(msg.Answer))
+	}
+}

--- a/records/txt.go
+++ b/records/txt.go
@@ -6,25 +6,21 @@ import (
 	"github.com/miekg/dns"
 )
 
-func AppendTXTRecords(msg *dns.Msg, qtype uint16, qname string, ttl int, value json.RawMessage) (bool, error) {
+func AppendTXTRecords(msg *dns.Msg, qname string, ttl int, value json.RawMessage) (bool, error) {
 	var values []string
 	if err := json.Unmarshal(value, &values); err != nil {
 		return false, err
 	}
 
-	txtAnswered := false
+	if len(values) == 0 {
+		return false, nil
+	}
 
 	rr := &dns.TXT{
 		Hdr: dns.RR_Header{Name: dns.Fqdn(qname), Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: uint32(ttl)},
 		Txt: values,
 	}
+	msg.Answer = append(msg.Answer, rr)
 
-	if qtype == dns.TypeTXT {
-		msg.Answer = append(msg.Answer, rr)
-		txtAnswered = true
-	} else {
-		msg.Extra = append(msg.Extra, rr)
-	}
-
-	return txtAnswered, nil
+	return true, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -60,14 +60,14 @@ func GetZoneAndRecord(zones []string, qname string) (string, string) {
 	qname = strings.TrimSuffix(dns.Fqdn(qname), ".")
 
 	for _, zone := range zones {
-		if strings.HasSuffix(qname, zone) {
-			record := strings.TrimSuffix(qname, zone)
-			record = strings.TrimSuffix(record, ".")
+		z := strings.TrimSuffix(zone, ".")
 
-			if record == "" {
-				record = "@"
-			}
+		if qname == z {
+			return zone, "@"
+		}
 
+		if strings.HasSuffix(qname, "."+z) {
+			record := strings.TrimSuffix(qname, "."+z)
 			return zone, record
 		}
 	}


### PR DESCRIPTION
Fixes the correctness bugs from the code audit and refactors the record dispatch.

## Correctness
- **External CNAME success check** — `HandleExternalCNAME` compared `len(answer) > len(answer)-1` (always true). It now compares the answer count before and after downstream resolution, so a failed external lookup is detected.
- **Zone matching** — `GetZoneAndRecord` used an unbounded suffix match, so `notexample.com` matched a configured `example.com`. It now matches only on a label boundary (exact zone or `.zone` suffix).
- **CNAME flattening query type** — flattening hardcoded `dns.TypeA`, so AAAA queries dropped AAAA answers. It now threads the original query type.
- **Flattening default** — an omitted `flattening` field left the zero value `""`, which behaved like `local` only by accident. `ApplyDefaults` now sets it to `local` explicitly (on both initial load and watch updates).
- **SOA on error** — `GetSOARecordFromConsul` returned a default SOA alongside a non-nil error, masking a Consul outage as NODATA. It now returns `(nil, err)` on failure and the default only when the zone genuinely has no SOA.
- **IP validation** — A/AAAA appenders emitted malformed records for invalid or wrong-family values. They now skip bad entries (logging a warning) and report found only when a valid record was added.
- **TXT scope** — TXT is only answered for TXT queries now, consistent with the other record types (it was previously attached as Additional to unrelated queries).

## Refactor
- `HandleRecord`'s 11-case type switch is replaced by a `recordAppenders` dispatch map plus a `finalizeAnswer` helper, bringing each function within the size/complexity limits. CNAME stays inline because it recurses into `HandleRecord`.

## Tests
Hermetic tests in `record_handling_test.go` and `records/records_test.go` cover zone-boundary matching, the flattening default, CNAME applicability, external-CNAME success/failure detection, A/AAAA validation, and TXT handling. `go build`, `go vet`, and all tests pass under `-race`.