### PR TITLE
Add CI workflow for build, vet, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-clean:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race ./...


### PR DESCRIPTION
Adds a `CI` workflow that runs on pushes to `main` and on pull requests:

- `gofmt` formatting check
- `go vet ./...`
- `go build ./...`
- `go test -race ./...`

Go version comes from `go.mod` via `setup-go`'s `go-version-file`. Actions are pinned to commit SHAs (checkout v7.0.0, setup-go v6.5.0) with `persist-credentials: false` and read-only `contents` permission.

Note: the existing `release.yml` still uses unpinned `@v2` actions and has a latent shell bug (`= "windows"]` is missing a space, so the Windows `.exe` branch never fires). Left for a separate PR.